### PR TITLE
cleanup for Devito easyconfig

### DIFF
--- a/easybuild/easyconfigs/d/Devito/Devito-4.6.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/d/Devito/Devito-4.6.1-foss-2020a-Python-3.8.2.eb
@@ -1,24 +1,24 @@
 easyblock = 'PythonBundle'
 
-name = 'devito'
+name = 'Devito'
 version = '4.6.1'
-versionsuffix = '-Python-3.8.2'
+versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://devitoproject.org/'
 description = "Devito is a domain-specific Language (DSL) and code generation framework"
 
 toolchain = {'name': 'foss', 'version': '2020a'}
-toolchainopts = {'pic': True, 'lowopt': True}
+toolchainopts = {'pic': True}
 
 dependencies = [
     ('Python', '3.8.2'),
     ('PyYAML', '5.3'),
     ('SciPy-bundle', '2020.03', versionsuffix), 
     ('IPython', '7.15.0', versionsuffix),
+    ('dask', '2021.12.0', versionsuffix),
 ]
 
 use_pip = True
-sanity_pip_check = True
 
 # order is important!
 exts_list = [
@@ -34,38 +34,20 @@ exts_list = [
     ('codecov', '2.1.12', {
         'checksums': ['a0da46bb5025426da895af90938def8ee12d37fcbcbbbc15b6dc64cf7ebc51c1'],
     }),
+    ('setuptools_scm', '6.0.1', {
+        'checksums': ['d1925a69cb07e9b29416a275b9fadb009a23c148ace905b2fb220649a6c18e92'],
+    }),
+    ('platformdirs', '2.2.0', {
+        'checksums': ['632daad3ab546bd8e6af0537d09805cec458dce201bccfe23012df73332e181e'],
+    }),
+    ('pytools', '2022.1', {
+        'checksums': ['197aacf6e1f5d60c715b92438792acb7702aed59ebbfb147fa84eda780e54fee'],
+    }),
     ('codepy', '2019.1', {
         'checksums': ['384f22c37fe987c0ca71951690c3c2fd14dacdeddbeb0fde4fd01cd84859c94e'],
     }),
-    ('distributed', '2021.12.0', {
-        'checksums': ['c6119a2cf1fb2d8ac60337915bb9a790af6530afcb5d7a809a3308323b874714'],
-    }),
-    ('cloudpickle', '2.0.0', {
-        'checksums': ['5cd02f3b417a783ba84a4ec3e290ff7929009fe51f6405423cfccfadd43ba4a4'],
-    }),
-    ('dask', '2021.12.0', {
-        'checksums': ['90614c9d162713e4849532c86f2854e8d53468521285413403b6c496344c0109'],
-    }),
-    ('msgpack', '1.0.3', {
-        'checksums': ['51fdc7fb93615286428ee7758cecc2f374d5ff363bdd884c7ea622a7a327a81e'],
-    }),
     ('coverage', '6.3.1', {
         'checksums': ['6c3f6158b02ac403868eea390930ae64e9a9a2a5bbfafefbb920d29258d9f2f8'],
-    }),
-    ('tblib', '1.7.0', {
-        'checksums': ['059bd77306ea7b419d4f76016aef6d7027cc8a0785579b5aad198803435f882c'],
-    }),
-    ('toolz', '0.11.2', {
-        'checksums': ['6b312d5e15138552f1bda8a4e66c30e236c831b612b2bf0005f8a1df10a4bc33'],
-    }),
-    ('tornado', '6.1', {
-        'checksums': ['33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791'],
-    }),
-    ('zict', '2.0.0', {
-        'checksums': ['8e2969797627c8a663575c2fc6fcb53a05e37cdb83ee65f341fc6e0c3d0ced16'],
-    }),
-    ('flake8', '4.0.1', {
-        'checksums': ['806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d'],
     }),
     ('mccabe', '0.6.1', {
         'checksums': ['dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f'],
@@ -76,8 +58,8 @@ exts_list = [
     ('pyflakes', '2.4.0', {
         'checksums': ['05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c'],
     }),
-    ('HeapDict', '1.0.1', {
-        'checksums': ['8495f57b3e03d8e46d5f1b2cc62ca881aca392fd5cc048dc0aa2e1a6d23ecdb6'],
+    ('flake8', '4.0.1', {
+        'checksums': ['806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d'],
     }),
     ('multidict', '6.0.2', {
         'checksums': ['5ff3bd75f38e4c43f1f470f2df7a4d430b821c4ce22be384e1459cb57d6bb013'],
@@ -89,6 +71,9 @@ exts_list = [
         'modulename': 'cpuinfo',
         'checksums': ['5f269be0e08e33fd959de96b34cd4aeeeacac014dd8305f70eb28d06de2345c5'],
     }),
+    ('contexttimer', '0.3.3', {
+        'checksums': ['35a1efd389af3f1ca509f33ff23e17d98b66c8fde5ba2a4eb8a8b7fa456598a5'],
+    }),
     ('pyrevolve', '2.2', {
         'checksums': ['b49aea5cd6c520ac5fcd1d25fa23fe2c5502741d2965f3eee10be067e7b0efb4'],
     }),
@@ -99,33 +84,15 @@ exts_list = [
         'modulename': 'pytest',
         'checksums': ['0fce5b8dc68760f353979d99fdd6b3ad46330b6b1837e2077a89ebcf204aac91'],
     }),
-    ('devito', '4.6.1', {
-        'checksums': ['e8acc4840953547c267706195df32738c95d0e51f7592eb0796a0efcc8cc5dbf'],
-    }),
-    ('contexttimer', '0.3.3', {
-        'checksums': ['35a1efd389af3f1ca509f33ff23e17d98b66c8fde5ba2a4eb8a8b7fa456598a5'],
-    }),
+    # devito requires sympy<=1.9,>=1.7
     ('sympy', '1.9', {
         'checksums': ['c7a880e229df96759f955d4f3970d4cabce79f60f5b18830c08b90ce77cd5fdc'],
     }),
-    ('fsspec', '2022.1.0', {
-        'checksums': ['0bdd519bbf4d8c9a1d893a50b5ebacc89acd0e1fe0045d2f7b0e0c1af5990edc'],
-    }),
-    ('partd', '1.2.0', {
-        'checksums': ['aa67897b84d522dcbc86a98b942afab8c6aa2f7f677d904a616b74ef5ddbc3eb'],
-    }),
-    ('pytools', '2022.1', {
-        'checksums': ['197aacf6e1f5d60c715b92438792acb7702aed59ebbfb147fa84eda780e54fee'],
-    }),
-    ('setuptools_scm', '6.0.1', {
-        'checksums': ['d1925a69cb07e9b29416a275b9fadb009a23c148ace905b2fb220649a6c18e92'],
-    }),
-    ('platformdirs', '2.2.0', {
-        'checksums': ['632daad3ab546bd8e6af0537d09805cec458dce201bccfe23012df73332e181e'],
-    }),
-    ('locket', '0.2.1', {
-        'checksums': ['3e1faba403619fe201552f083f1ecbf23f550941bc51985ac6ed4d02d25056dd'],
+    ('devito', version, {
+        'checksums': ['e8acc4840953547c267706195df32738c95d0e51f7592eb0796a0efcc8cc5dbf'],
     }),
 ]
+
+sanity_pip_check = True
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/d/Devito/Devito-4.6.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/d/Devito/Devito-4.6.1-foss-2020a-Python-3.8.2.eb
@@ -4,7 +4,7 @@ name = 'Devito'
 version = '4.6.1'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'https://devitoproject.org/'
+homepage = ' https://www.devitoproject.org'
 description = "Devito is a domain-specific Language (DSL) and code generation framework"
 
 toolchain = {'name': 'foss', 'version': '2020a'}


### PR DESCRIPTION
@hmeiland for https://github.com/easybuilders/easybuild-easyconfigs/pull/14984

* use official software name for Devito,
* add `dask` as proper dependency + remove unneeded extensions
* don't use lowopt toolchain option
* fix homepage