### PR TITLE
{FFTW}[GCC/14.3.0] FFTW v3.3.10 w/ RISC-V Vector (r5v) backend

### DIFF
--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.10-GCC-14.3.0-r5v.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.10-GCC-14.3.0-r5v.eb
@@ -1,0 +1,60 @@
+name = 'FFTW'
+version = '3.3.10'
+versionsuffix = '-r5v'
+
+homepage = 'https://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+in one or more dimensions, of arbitrary input size, and of both real and complex data.
+
+This build enables the RISC-V Vector (RVV) SIMD backend via --enable-r5v, from
+rdolbeau's r5v-test-release-005 fork of FFTW 3.3.10, targeting the SpaceMiT
+X60/K1 (rv64imafdcv, VLEN=256). Double precision, shared, single-threaded."""
+
+# Compiler-only toolchain (EESSI 2025.06-001 GCC 14.3.0). pic:True makes the
+# FFTW easyblock add --with-pic + --enable-shared automatically per precision.
+# The K1 vector -march is pinned in configopts below (see comment there).
+toolchain = {'name': 'GCC', 'version': '14.3.0'}
+toolchainopts = {'pic': True}
+
+# The r5v source is NOT the stock www.fftw.org tarball: it is rdolbeau's
+# r5v-test-release-005 fork, repackaged with a stock fftw-3.3.10/ top dir.
+# Place fftw-r5v.tar.gz in your sourcepath (or next to this .eb) before building.
+sources = ['fftw-r5v.tar.gz']
+checksums = ['65f81f8072c640d5b3da4b11f6da39b20370d4040971be0797d8f7aeae9f8fd3']
+
+# Match the validated A/B build (see fftw/build-fftw-r5v.sh): double precision
+# only, shared, no fortran wrapper lib / doc / mpi / threads / openmp.
+with_double_prec = True
+with_single_prec = False
+with_long_double_prec = False
+with_quad_prec = False
+
+with_shared = True
+with_threads = False
+with_openmp = False
+with_mpi = False
+
+# The FFTW easyblock auto-detects x86/ARM/POWER SIMD (avx/sse/neon/sve/...) but
+# has NO RVV entry, so detection is a no-op on riscv64. Turn it off to keep the
+# configure line deterministic; --enable-r5v is what actually enables RVV.
+auto_detect_cpu_features = False
+
+# --enable-r5v is the ONLY functional delta vs a stock scalar build; the -march
+# string is what makes the r5v codelets emit RVV 1.0 (VLEN>=256). configopts is
+# appended verbatim to each precision's ./configure line by the easyblock, so
+# passing CFLAGS= here is the supported pattern (cf. the easyblock's Fujitsu
+# branch). --disable-fortran skips only the Fortran wrapper LIB; the fftw3.f /
+# fftw3.f03 headers the easyblock sanity-checks are still installed.
+configopts = '--enable-r5v --disable-fortran '
+configopts += 'CFLAGS="-O3 -march=rv64imafdcv_zvl256b"'
+
+# stock FFTW 'make check'. On the X60 this is slow; run with --skip-test-step
+# (or set runtest to False) if you only want the libraries.
+runtest = 'check'
+
+# NOTE: sanity_check_paths is intentionally NOT set here. The FFTW easyblock
+# generates a precision-aware custom sanity check (fftw3.h, fftw3.f/.f03,
+# bin/fftw-wisdom, lib/libfftw3.a + .so, lib/pkgconfig) and passes it to the
+# generic step, overriding any list given in this easyconfig.
+
+moduleclass = 'numlib'


### PR DESCRIPTION
Experimental easyconfig for **FFTW 3.3.10 with the RISC-V Vector (RVV) `r5v` SIMD backend** (`--enable-r5v`), targeting the SpaceMiT X60/K1 (`rv64imafdcv`, VLEN=256) on EESSI GCC 14.3.0. Kept on this fork for RISC-V RVV experimentation.

Full A/B analysis (r5v vs scalar, planner study) lives in [opensolvers/benchmarks#13](https://github.com/opensolvers/benchmarks/pull/13): the RVV backend is real (224k vector instrs vs 734 scalar, `*_r5v256` codelets selected) and 1.06–1.60× faster than scalar under `FFTW_MEASURE`.

### What it does
- Stock `EB_FFTW` easyblock, `GCC/14.3.0` toolchain, double-precision + shared only.
- `configopts = '--enable-r5v --disable-fortran CFLAGS="-O3 -march=rv64imafdcv_zvl256b"'`
- `auto_detect_cpu_features = False` (easyblock has no RVV entry; detection is a no-op on riscv64).
- Verified to **parse cleanly against EasyBuild 5.3.1** (framework + `EB_FFTW` accept all params; module `FFTW/3.3.10-GCC-14.3.0-r5v`).

### ⚠️ Why this is NOT upstream-ready (kept on fork intentionally)
1. **Source is a fork, not an official release** — rdolbeau's `r5v-test-release-005`, repackaged as `fftw-r5v.tar.gz` (sha256 `65f81f80…9f8fd3`). No permanent public `source_urls`.
2. **`--enable-r5v` is not supported by the upstream FFTW easyblock** — it's passed as a raw `configopts` string rather than proper easyblock/`use_*` handling.
3. **`-march` is hardcoded in `CFLAGS`**, bypassing the `--optarch` contract that upstream easyconfigs must respect.

Upstreaming would require: a published r5v source, RVV support added to the FFTW easyblock, and dropping the pinned `-march`.